### PR TITLE
feat: add mocking setup

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,8 +11,8 @@ export default tseslint.config(
   { ignores: ['dist', 'vite.config.ts', 'src/vite-env.d.ts'] },
   {
     extends: [
-      js.configs.recommended, 
-      ...tseslint.configs.recommendedTypeChecked, 
+      js.configs.recommended,
+      ...tseslint.configs.recommendedTypeChecked,
       ...tseslint.configs.stylisticTypeChecked
     ],
     files: ['**/*.{ts,tsx}'],
@@ -21,10 +21,12 @@ export default tseslint.config(
       ecmaVersion: 2020,
       globals: globals.browser,
       parserOptions: {
+        // This is new and could cause some problems, just restart the ESlint server when it complains about files not to be included
+        // even though they are included via the src directory.
         projectService: true,
         project: ['./tsconfig.node.json', './tsconfig.app.json'],
         tsconfigRootDir: import.meta.dirname
-      }
+        }
     },
     plugins: {
       react,
@@ -44,448 +46,448 @@ export default tseslint.config(
       ],
 
       "vitest/max-nested-describe": [
-      "error",
-      {
-        "max": 3
-      }
-    ],
-    // eslint
-    'array-bracket-newline': [ 'error', { multiline: true } ],
-    'array-bracket-spacing': [ 'error', 'always', {
-      objectsInArrays: false,
-      arraysInArrays: false
-    }],
-    'array-element-newline': [ 'error', 'consistent' ],
-    'arrow-spacing': ['error'],
-    'block-spacing': [ 'error' ],
-    'function-call-argument-newline': [ 'error', 'consistent' ],
-    'function-paren-newline': [ 'error', 'multiline-arguments' ],
-    'no-mixed-operators': [ 'error' ],
-    'no-multiple-empty-lines': [ 'error', {
-      max: 1
-    }],
-    'no-multi-spaces': [ 'error' ],
-    'no-trailing-spaces': [ 'error' ],
-    'max-len': [ 'error', {
-      code: 120,
-      tabWidth: 2,
-      ignoreStrings: true,
-      ignoreTemplateLiterals: true,
-    }],
-    'multiline-ternary': [ 'error', 'always-multiline' ],
-    'object-curly-newline': [ 'error', {
-      multiline: true,
-      consistent: true,
-    }],
-    'object-property-newline': [ 'error', {
-      allowAllPropertiesOnSameLine: true
-    }],
-    'operator-linebreak': [ 'error', 'before', {
-      overrides: { '=': 'after' }
-    }],
-    'padded-blocks': [ 'error', 'never' ],
-    'require-await': ['off'],
-    "sort-imports": ['error', {
-      ignoreCase: true,
-      ignoreDeclarationSort: false,
-      ignoreMemberSort: false,
-      memberSyntaxSortOrder: [
-        'single',
-        'multiple',
-        'all',
-        'none'
-      ]
-    }],
-    'space-in-parens': ['error', 'never'],
-    'yoda': [ 'error' ],
-    'react/function-component-definition': [ 'error', {
-      namedComponents: 'arrow-function',
-      unnamedComponents: 'arrow-function'
-    }],
-    'react/no-adjacent-inline-elements': [ 'off' ],
-    'react/forbid-component-props': [ 'off' ],
-    'react/no-set-state': [ 'off' ],
-    'react/react-in-jsx-scope': [ 'off' ],
-    'react/require-default-props': [ 'off' ],
-    'react/sort-comp': [ 'off' ],
-    'react/jsx-boolean-value': [ 'off' ],
-    'react/jsx-curly-newline': [ 'error', {
-      singleline: 'consistent',
-      multiline: 'consistent'
-    }],
-    'react/jsx-curly-spacing': [ 'error', {
-      'when': 'always',
-      'children': true,
-      'spacing': {
-        'objectLiterals': 'never'
-      }
-    }],
-    'react/jsx-filename-extension': [ 'error', {
-      'extensions': [ '.tsx' ]
-    }],
-    'react/jsx-first-prop-new-line': [ 'error', 'multiline'],
-    'react/jsx-handler-names': [ 'error', {
-      checkLocalVariables: true,
-    }],
-    'react/jsx-indent': ['error', 'tab', {
-      checkAttributes: false,
-      indentLogicalExpressions: true
-    }],
-    'react/jsx-indent-props': [ 'error', 'tab' ],
-    'react/jsx-max-depth': [ 'off' ],
-    'react/jsx-newline': [ 'off' ],
-    'react/jsx-no-literals': [ 'off' ],
-    'react/jsx-one-expression-per-line': [ 'off' ],
-    'react/jsx-props-no-spreading': [ 'error', {
-      custom: 'ignore'
-    }],
-    'react/jsx-wrap-multilines': [ 'error', {
-      declaration: 'parens-new-line',
-      assignment: 'parens-new-line',
-      return: 'parens-new-line',
-      arrow: 'parens-new-line',
-      condition: 'parens-new-line',
-      logical: 'parens-new-line',
-      prop: 'ignore'
-    }],
-    // eslint-plugin-react-hooks
-    'react-hooks/rules-of-hooks': [ 'error' ],
-    'react-hooks/exhaustive-deps': [ 'error' ],
-
-    // @typescript-eslint/eslint-plugin
-    '@typescript-eslint/no-explicit-any': [ 'error' ],
-    '@typescript-eslint/no-non-null-assertion': [ 'error' ],
-    '@typescript-eslint/no-unused-vars': [ 'error' ],
-    '@typescript-eslint/explicit-function-return-type': [ 'error', {
-      allowTypedFunctionExpressions: true,
-    }],
-    '@typescript-eslint/array-type': [ 'error' ],
-    '@typescript-eslint/ban-tslint-comment': [ 'error' ],
-    '@typescript-eslint/class-literal-property-style': [ 'error' ],
-    '@typescript-eslint/consistent-type-assertions': [ 'error', {
-      assertionStyle: 'as',
-      objectLiteralTypeAssertions: 'never'
-    }],
-    '@typescript-eslint/consistent-type-definitions': [ 'error' ],
-    '@typescript-eslint/no-base-to-string': [ 'error' ],
-    '@typescript-eslint/no-confusing-non-null-assertion': [ 'error' ],
-    '@typescript-eslint/no-duplicate-enum-values': [ 'error' ],
-    '@typescript-eslint/no-dynamic-delete': [ 'error' ],
-    '@typescript-eslint/no-extraneous-class': [ 'error' ],
-    '@typescript-eslint/no-invalid-void-type': [ 'off' ],
-    '@typescript-eslint/no-meaningless-void-operator': [ 'error' ],
-    '@typescript-eslint/no-non-null-asserted-nullish-coalescing': [ 'error' ],
-    '@typescript-eslint/no-unnecessary-boolean-literal-compare': [ 'error' ],
-    '@typescript-eslint/no-unnecessary-condition': [ 'error' ],
-    '@typescript-eslint/no-unnecessary-type-arguments': [ 'error' ],
-    '@typescript-eslint/non-nullable-type-assertion-style': [ 'error' ],
-    '@typescript-eslint/prefer-for-of': [ 'error' ],
-    '@typescript-eslint/prefer-function-type': [ 'error' ],
-    '@typescript-eslint/prefer-includes': [ 'error' ],
-    '@typescript-eslint/prefer-literal-enum-member': [ 'error' ],
-    '@typescript-eslint/prefer-nullish-coalescing': [ 'error' ],
-    '@typescript-eslint/prefer-optional-chain': [ 'error' ],
-    '@typescript-eslint/prefer-reduce-type-parameter': [ 'error' ],
-    '@typescript-eslint/prefer-return-this-type': [ 'error' ],
-    '@typescript-eslint/prefer-string-starts-ends-with': [ 'error' ],
-    '@typescript-eslint/prefer-ts-expect-error': [ 'error' ],
-    '@typescript-eslint/require-await': ['off'],
-    '@typescript-eslint/unified-signatures': [ 'error' ],
-    '@typescript-eslint/consistent-type-exports': [ 'error' ],
-    '@typescript-eslint/consistent-type-imports': [ 'error' ],
-    '@typescript-eslint/explicit-member-accessibility': [ 'error' ],
-    '@typescript-eslint/explicit-module-boundary-types': [ 'error' ],
-    "@typescript-eslint/member-ordering": [
-      "error",
-      {
-        "default": {
-          "memberTypes": [
-            // Index signature
-            "signature",
-            "call-signature",
-
-            // Fields
-            "public-static-field",
-            "protected-static-field",
-            "private-static-field",
-            "#private-static-field",
-
-            "public-decorated-field",
-            "protected-decorated-field",
-            "private-decorated-field",
-
-            "public-instance-field",
-            "protected-instance-field",
-            "private-instance-field",
-            "#private-instance-field",
-
-            "public-abstract-field",
-            "protected-abstract-field",
-
-            "public-field",
-            "protected-field",
-            "private-field",
-            "#private-field",
-
-            "static-field",
-            "instance-field",
-            "abstract-field",
-
-            "decorated-field",
-
-            "field",
-
-            // Static initialization
-            "static-initialization",
-
-            // Constructors
-            "public-constructor",
-            "protected-constructor",
-            "private-constructor",
-
-            "constructor",
-
-            // Getters
-            "public-static-get",
-            "protected-static-get",
-            "private-static-get",
-            "#private-static-get",
-
-            "public-decorated-get",
-            "protected-decorated-get",
-            "private-decorated-get",
-
-            "public-instance-get",
-            "protected-instance-get",
-            "private-instance-get",
-            "#private-instance-get",
-
-            "public-abstract-get",
-            "protected-abstract-get",
-
-            "public-get",
-            "protected-get",
-            "private-get",
-            "#private-get",
-
-            "static-get",
-            "instance-get",
-            "abstract-get",
-
-            "decorated-get",
-
-            "get",
-
-            // Setters
-            "public-static-set",
-            "protected-static-set",
-            "private-static-set",
-            "#private-static-set",
-
-            "public-decorated-set",
-            "protected-decorated-set",
-            "private-decorated-set",
-
-            "public-instance-set",
-            "protected-instance-set",
-            "private-instance-set",
-            "#private-instance-set",
-
-            "public-abstract-set",
-            "protected-abstract-set",
-
-            "public-set",
-            "protected-set",
-            "private-set",
-            "#private-set",
-
-            "static-set",
-            "instance-set",
-            "abstract-set",
-
-            "decorated-set",
-
-            "set",
-
-            // Methods
-            "public-static-method",
-            "protected-static-method",
-            "private-static-method",
-            "#private-static-method",
-
-            "public-decorated-method",
-            "protected-decorated-method",
-            "private-decorated-method",
-
-            "public-instance-method",
-            "protected-instance-method",
-            "private-instance-method",
-            "#private-instance-method",
-
-            "public-abstract-method",
-            "protected-abstract-method",
-
-            "public-method",
-            "protected-method",
-            "private-method",
-            "#private-method",
-
-            "static-method",
-            "instance-method",
-            "abstract-method",
-
-            "decorated-method",
-
-            "method"
-          ],
-          "order": "alphabetically"
+        "error",
+        {
+          "max": 3
         }
-      }
-    ],
-    '@typescript-eslint/method-signature-style': [ 'error' ],
-    'camelcase': 'off',
-    '@typescript-eslint/naming-convention': [ 'error',
-      {
-        selector: 'default',
-        format: ['camelCase']
-      },
-      {
-        selector: 'function',
-        format: ['camelCase', 'PascalCase']
-      },
-      {
-        selector: 'variable',
-        format: ['camelCase', 'PascalCase', 'UPPER_CASE']
-      },
-      {
-        selector: 'parameter',
-        format: ['camelCase'],
-        leadingUnderscore: 'allow',
-      },
-      {
-        selector: 'enumMember',
-        format: ['UPPER_CASE']
-      },
-      {
-        selector: 'typeLike',
-        format: ['PascalCase']
-      },
-      {
-        selector: 'import',
-        format: ['camelCase', 'PascalCase'],
-      }
-    ],
-    '@typescript-eslint/no-confusing-void-expression': [ 'error' ],
-    '@typescript-eslint/no-redundant-type-constituents': [ 'error' ],
-    // We use unicorn/prefer-module instead
-    '@typescript-eslint/no-require-imports': [ 'off' ],
-    '@typescript-eslint/no-unnecessary-qualifier': [ 'error' ],
-    '@typescript-eslint/no-useless-empty-export': [ 'error' ],
-    // We use unicorn/prefer-module instead
-    '@typescript-eslint/no-var-requires': [ 'off' ],
-    '@typescript-eslint/parameter-properties': [ 'error' ],
-    '@typescript-eslint/prefer-enum-initializers': [ 'error' ],
-    '@typescript-eslint/prefer-readonly': [ 'error' ],
-    '@typescript-eslint/prefer-regexp-exec': [ 'error' ],
-    '@typescript-eslint/promise-function-async': [ 'error' ],
-    '@typescript-eslint/require-array-sort-compare': [ 'error' ],
-    '@typescript-eslint/sort-type-constituents': [ 'error' ],
-    '@typescript-eslint/strict-boolean-expressions': [ 'warn'],
-    '@typescript-eslint/switch-exhaustiveness-check': [ 'error' ],
+      ],
+      // eslint
+      'array-bracket-newline': ['error', { multiline: true }],
+      'array-bracket-spacing': ['error', 'always', {
+        objectsInArrays: false,
+        arraysInArrays: false
+      }],
+      'array-element-newline': ['error', 'consistent'],
+      'arrow-spacing': ['error'],
+      'block-spacing': ['error'],
+      'function-call-argument-newline': ['error', 'consistent'],
+      'function-paren-newline': ['error', 'multiline-arguments'],
+      'no-mixed-operators': ['error'],
+      'no-multiple-empty-lines': ['error', {
+        max: 1
+      }],
+      'no-multi-spaces': ['error'],
+      'no-trailing-spaces': ['error'],
+      'max-len': ['error', {
+        code: 120,
+        tabWidth: 2,
+        ignoreStrings: true,
+        ignoreTemplateLiterals: true,
+      }],
+      'multiline-ternary': ['error', 'always-multiline'],
+      'object-curly-newline': ['error', {
+        multiline: true,
+        consistent: true,
+      }],
+      'object-property-newline': ['error', {
+        allowAllPropertiesOnSameLine: true
+      }],
+      'operator-linebreak': ['error', 'before', {
+        overrides: { '=': 'after' }
+      }],
+      'padded-blocks': ['error', 'never'],
+      'require-await': ['off'],
+      "sort-imports": ['error', {
+        ignoreCase: true,
+        ignoreDeclarationSort: false,
+        ignoreMemberSort: false,
+        memberSyntaxSortOrder: [
+          'single',
+          'multiple',
+          'all',
+          'none'
+        ]
+      }],
+      'space-in-parens': ['error', 'never'],
+      'yoda': ['error'],
+      'react/function-component-definition': ['error', {
+        namedComponents: 'arrow-function',
+        unnamedComponents: 'arrow-function'
+      }],
+      'react/no-adjacent-inline-elements': ['off'],
+      'react/forbid-component-props': ['off'],
+      'react/no-set-state': ['off'],
+      'react/react-in-jsx-scope': ['off'],
+      'react/require-default-props': ['off'],
+      'react/sort-comp': ['off'],
+      'react/jsx-boolean-value': ['off'],
+      'react/jsx-curly-newline': ['error', {
+        singleline: 'consistent',
+        multiline: 'consistent'
+      }],
+      'react/jsx-curly-spacing': ['error', {
+        'when': 'always',
+        'children': true,
+        'spacing': {
+          'objectLiterals': 'never'
+        }
+      }],
+      'react/jsx-filename-extension': ['error', {
+        'extensions': ['.tsx']
+      }],
+      'react/jsx-first-prop-new-line': ['error', 'multiline'],
+      'react/jsx-handler-names': ['error', {
+        checkLocalVariables: true,
+      }],
+      'react/jsx-indent': ['error', 'tab', {
+        checkAttributes: false,
+        indentLogicalExpressions: true
+      }],
+      'react/jsx-indent-props': ['error', 'tab'],
+      'react/jsx-max-depth': ['off'],
+      'react/jsx-newline': ['off'],
+      'react/jsx-no-literals': ['off'],
+      'react/jsx-one-expression-per-line': ['off'],
+      'react/jsx-props-no-spreading': ['error', {
+        custom: 'ignore'
+      }],
+      'react/jsx-wrap-multilines': ['error', {
+        declaration: 'parens-new-line',
+        assignment: 'parens-new-line',
+        return: 'parens-new-line',
+        arrow: 'parens-new-line',
+        condition: 'parens-new-line',
+        logical: 'parens-new-line',
+        prop: 'ignore'
+      }],
+      // eslint-plugin-react-hooks
+      'react-hooks/rules-of-hooks': ['error'],
+      'react-hooks/exhaustive-deps': ['error'],
 
-    // typescript-eslint extensions
-    'brace-style': [ 'off' ],
-    '@/brace-style': [ 'error', '1tbs' ],
-    'comma-dangle': ['off'],
-    '@/comma-dangle': [ 'error', {
-      arrays: 'always-multiline',
-      objects: 'always-multiline',
-      imports: 'always-multiline',
-      exports: 'always-multiline',
-      functions: 'always-multiline',
-  }],
-    'comma-spacing': ['off'],
-    '@/comma-spacing': [ 'error' ],
-    'default-param-last': [ 'off' ],
-    '@typescript-eslint/default-param-last': [ 'error' ],
-    'dot-notation': [ 'off' ],
-    '@typescript-eslint/dot-notation': [ 'error' ],
-    'func-call-spacing': ['off'],
-    '@/func-call-spacing': [ 'error' ],
-    'indent': [ 'off' ],
-    '@/indent': [ 'error', 'tab' ],
-    'keyword-spacing': ['off'],
-    '@/keyword-spacing': ['error', { after: true }],
-    'lines-between-class-members': ['off'],
-    '@/lines-between-class-members': ['error', "always", { "exceptAfterSingleLine": true }],
-    'no-array-constructor': ['off'],
-    '@typescript-eslint/no-array-constructor': ['error'],
-    'no-dupe-class-members': ['off'],
-    '@typescript-eslint/no-dupe-class-members': ['error'],
-    'no-extra-parens': ['off'],
-    '@typescript-eslint/no-extra-parens': ['off'],
-    'no-invalid-this': ['off'],
-    '@typescript-eslint/no-invalid-this': ['error'],
-    'no-loop-func': ['off'],
-    '@typescript-eslint/no-loop-func': ['error'],
-    'no-redeclare': ['off'],
-    '@typescript-eslint/no-redeclare': ['error'],
-    'no-shadow': ['off'],
-    '@typescript-eslint/no-shadow': ['error'],
-    'no-throw-literal': [ 'off' ],
-    '@/no-throw-literal': [ 'error' ],
-    'no-unused-expressions': ['off'],
-    '@typescript-eslint/no-unused-expressions': ['error'],
-    'no-use-before-define': ['off'],
-    '@typescript-eslint/no-use-before-define': ['error'],
-    'no-useless-constructor': [ 'off' ],
-    '@typescript-eslint/no-useless-constructor': [ 'error' ],
-    'object-curly-spacing': ['off'],
-    '@/object-curly-spacing': ['error', 'always'],
-    'padding-line-between-statements': ['off'],
-    '@/padding-line-between-statements': ['error',
-      { blankLine: 'always', prev: '*', next: 'return' },
-      { blankLine: 'always', prev: [ 'const', 'let', 'var' ], next: '*' },
-      { blankLine: 'any', prev: [ 'const', 'let', 'var' ], next: [ 'const', 'let', 'var' ]},
-      { blankLine: 'always', prev: 'directive', next: '*' },
-      { blankLine: 'any', prev: 'directive', next: 'directive' }
-    ],
-    'quotes': ['off'],
-    '@/quotes': ['error', 'single', {
-      avoidEscape: false,
-      allowTemplateLiterals: true
-    }],
-    'no-return-await': ['off'],
-    '@typescript-eslint/return-await': ['error', 'always'],
-    'semi': ['off'],
-    '@/semi': ['error', 'always'],
-    'space-before-blocks': [ 'off' ],
-    '@/space-before-blocks': [ 'error' ],
-    'space-before-function-paren': ['off'],
-    '@/space-before-function-paren': ['error', 'always'],
-    'space-infix-ops': ['off'],
-    '@/space-infix-ops': ['error'],
+      // @typescript-eslint/eslint-plugin
+      '@typescript-eslint/no-explicit-any': ['error'],
+      '@typescript-eslint/no-non-null-assertion': ['error'],
+      '@typescript-eslint/no-unused-vars': ['error'],
+      '@typescript-eslint/explicit-function-return-type': ['error', {
+        allowTypedFunctionExpressions: true,
+      }],
+      '@typescript-eslint/array-type': ['error'],
+      '@typescript-eslint/ban-tslint-comment': ['error'],
+      '@typescript-eslint/class-literal-property-style': ['error'],
+      '@typescript-eslint/consistent-type-assertions': ['error', {
+        assertionStyle: 'as',
+        objectLiteralTypeAssertions: 'never'
+      }],
+      '@typescript-eslint/consistent-type-definitions': ['error'],
+      '@typescript-eslint/no-base-to-string': ['error'],
+      '@typescript-eslint/no-confusing-non-null-assertion': ['error'],
+      '@typescript-eslint/no-duplicate-enum-values': ['error'],
+      '@typescript-eslint/no-dynamic-delete': ['error'],
+      '@typescript-eslint/no-extraneous-class': ['error'],
+      '@typescript-eslint/no-invalid-void-type': ['off'],
+      '@typescript-eslint/no-meaningless-void-operator': ['error'],
+      '@typescript-eslint/no-non-null-asserted-nullish-coalescing': ['error'],
+      '@typescript-eslint/no-unnecessary-boolean-literal-compare': ['error'],
+      '@typescript-eslint/no-unnecessary-condition': ['error'],
+      '@typescript-eslint/no-unnecessary-type-arguments': ['error'],
+      '@typescript-eslint/non-nullable-type-assertion-style': ['error'],
+      '@typescript-eslint/prefer-for-of': ['error'],
+      '@typescript-eslint/prefer-function-type': ['error'],
+      '@typescript-eslint/prefer-includes': ['error'],
+      '@typescript-eslint/prefer-literal-enum-member': ['error'],
+      '@typescript-eslint/prefer-nullish-coalescing': ['error'],
+      '@typescript-eslint/prefer-optional-chain': ['error'],
+      '@typescript-eslint/prefer-reduce-type-parameter': ['error'],
+      '@typescript-eslint/prefer-return-this-type': ['error'],
+      '@typescript-eslint/prefer-string-starts-ends-with': ['error'],
+      '@typescript-eslint/prefer-ts-expect-error': ['error'],
+      '@typescript-eslint/require-await': ['off'],
+      '@typescript-eslint/unified-signatures': ['error'],
+      '@typescript-eslint/consistent-type-exports': ['error'],
+      '@typescript-eslint/consistent-type-imports': ['error'],
+      '@typescript-eslint/explicit-member-accessibility': ['error'],
+      '@typescript-eslint/explicit-module-boundary-types': ['error'],
+      "@typescript-eslint/member-ordering": [
+        "error",
+        {
+          "default": {
+            "memberTypes": [
+              // Index signature
+              "signature",
+              "call-signature",
 
-    // eslint-plugin-unicorn
-    'unicorn/catch-error-name': [ 'error', {
-      name: 'ex'
-    }],
-    'unicorn/filename-case': [ 'warn', {
-      cases: {
-        camelCase: true,
-        pascalCase: true
-      }
-    }],
-    'unicorn/no-null': [ 'off' ],
-    'unicorn/no-useless-undefined': [ 'off' ],
-    'unicorn/prevent-abbreviations': [ 'warn', {
-      replacements: {
-        args: false,
-        props: false
-      }
-    }],
-    'unicorn/prefer-ternary': [ 'off' ],
-    'unicorn/prefer-spread': [ 'off' ],
+              // Fields
+              "public-static-field",
+              "protected-static-field",
+              "private-static-field",
+              "#private-static-field",
+
+              "public-decorated-field",
+              "protected-decorated-field",
+              "private-decorated-field",
+
+              "public-instance-field",
+              "protected-instance-field",
+              "private-instance-field",
+              "#private-instance-field",
+
+              "public-abstract-field",
+              "protected-abstract-field",
+
+              "public-field",
+              "protected-field",
+              "private-field",
+              "#private-field",
+
+              "static-field",
+              "instance-field",
+              "abstract-field",
+
+              "decorated-field",
+
+              "field",
+
+              // Static initialization
+              "static-initialization",
+
+              // Constructors
+              "public-constructor",
+              "protected-constructor",
+              "private-constructor",
+
+              "constructor",
+
+              // Getters
+              "public-static-get",
+              "protected-static-get",
+              "private-static-get",
+              "#private-static-get",
+
+              "public-decorated-get",
+              "protected-decorated-get",
+              "private-decorated-get",
+
+              "public-instance-get",
+              "protected-instance-get",
+              "private-instance-get",
+              "#private-instance-get",
+
+              "public-abstract-get",
+              "protected-abstract-get",
+
+              "public-get",
+              "protected-get",
+              "private-get",
+              "#private-get",
+
+              "static-get",
+              "instance-get",
+              "abstract-get",
+
+              "decorated-get",
+
+              "get",
+
+              // Setters
+              "public-static-set",
+              "protected-static-set",
+              "private-static-set",
+              "#private-static-set",
+
+              "public-decorated-set",
+              "protected-decorated-set",
+              "private-decorated-set",
+
+              "public-instance-set",
+              "protected-instance-set",
+              "private-instance-set",
+              "#private-instance-set",
+
+              "public-abstract-set",
+              "protected-abstract-set",
+
+              "public-set",
+              "protected-set",
+              "private-set",
+              "#private-set",
+
+              "static-set",
+              "instance-set",
+              "abstract-set",
+
+              "decorated-set",
+
+              "set",
+
+              // Methods
+              "public-static-method",
+              "protected-static-method",
+              "private-static-method",
+              "#private-static-method",
+
+              "public-decorated-method",
+              "protected-decorated-method",
+              "private-decorated-method",
+
+              "public-instance-method",
+              "protected-instance-method",
+              "private-instance-method",
+              "#private-instance-method",
+
+              "public-abstract-method",
+              "protected-abstract-method",
+
+              "public-method",
+              "protected-method",
+              "private-method",
+              "#private-method",
+
+              "static-method",
+              "instance-method",
+              "abstract-method",
+
+              "decorated-method",
+
+              "method"
+            ],
+            "order": "alphabetically"
+          }
+        }
+      ],
+      '@typescript-eslint/method-signature-style': ['error'],
+      'camelcase': 'off',
+      '@typescript-eslint/naming-convention': ['error',
+        {
+          selector: 'default',
+          format: ['camelCase']
+        },
+        {
+          selector: 'function',
+          format: ['camelCase', 'PascalCase']
+        },
+        {
+          selector: 'variable',
+          format: ['camelCase', 'PascalCase', 'UPPER_CASE']
+        },
+        {
+          selector: 'parameter',
+          format: ['camelCase'],
+          leadingUnderscore: 'allow',
+        },
+        {
+          selector: 'enumMember',
+          format: ['UPPER_CASE']
+        },
+        {
+          selector: 'typeLike',
+          format: ['PascalCase']
+        },
+        {
+          selector: 'import',
+          format: ['camelCase', 'PascalCase'],
+        }
+      ],
+      '@typescript-eslint/no-confusing-void-expression': ['error'],
+      '@typescript-eslint/no-redundant-type-constituents': ['error'],
+      // We use unicorn/prefer-module instead
+      '@typescript-eslint/no-require-imports': ['off'],
+      '@typescript-eslint/no-unnecessary-qualifier': ['error'],
+      '@typescript-eslint/no-useless-empty-export': ['error'],
+      // We use unicorn/prefer-module instead
+      '@typescript-eslint/no-var-requires': ['off'],
+      '@typescript-eslint/parameter-properties': ['error'],
+      '@typescript-eslint/prefer-enum-initializers': ['error'],
+      '@typescript-eslint/prefer-readonly': ['error'],
+      '@typescript-eslint/prefer-regexp-exec': ['error'],
+      '@typescript-eslint/promise-function-async': ['error'],
+      '@typescript-eslint/require-array-sort-compare': ['error'],
+      '@typescript-eslint/sort-type-constituents': ['error'],
+      '@typescript-eslint/strict-boolean-expressions': ['warn'],
+      '@typescript-eslint/switch-exhaustiveness-check': ['error'],
+
+      // typescript-eslint extensions
+      'brace-style': ['off'],
+      '@/brace-style': ['error', '1tbs'],
+      'comma-dangle': ['off'],
+      '@/comma-dangle': ['error', {
+        arrays: 'always-multiline',
+        objects: 'always-multiline',
+        imports: 'always-multiline',
+        exports: 'always-multiline',
+        functions: 'always-multiline',
+      }],
+      'comma-spacing': ['off'],
+      '@/comma-spacing': ['error'],
+      'default-param-last': ['off'],
+      '@typescript-eslint/default-param-last': ['error'],
+      'dot-notation': ['off'],
+      '@typescript-eslint/dot-notation': ['error'],
+      'func-call-spacing': ['off'],
+      '@/func-call-spacing': ['error'],
+      'indent': ['off'],
+      '@/indent': ['error', 'tab'],
+      'keyword-spacing': ['off'],
+      '@/keyword-spacing': ['error', { after: true }],
+      'lines-between-class-members': ['off'],
+      '@/lines-between-class-members': ['error', "always", { "exceptAfterSingleLine": true }],
+      'no-array-constructor': ['off'],
+      '@typescript-eslint/no-array-constructor': ['error'],
+      'no-dupe-class-members': ['off'],
+      '@typescript-eslint/no-dupe-class-members': ['error'],
+      'no-extra-parens': ['off'],
+      '@typescript-eslint/no-extra-parens': ['off'],
+      'no-invalid-this': ['off'],
+      '@typescript-eslint/no-invalid-this': ['error'],
+      'no-loop-func': ['off'],
+      '@typescript-eslint/no-loop-func': ['error'],
+      'no-redeclare': ['off'],
+      '@typescript-eslint/no-redeclare': ['error'],
+      'no-shadow': ['off'],
+      '@typescript-eslint/no-shadow': ['error'],
+      'no-throw-literal': ['off'],
+      '@/no-throw-literal': ['error'],
+      'no-unused-expressions': ['off'],
+      '@typescript-eslint/no-unused-expressions': ['error'],
+      'no-use-before-define': ['off'],
+      '@typescript-eslint/no-use-before-define': ['error'],
+      'no-useless-constructor': ['off'],
+      '@typescript-eslint/no-useless-constructor': ['error'],
+      'object-curly-spacing': ['off'],
+      '@/object-curly-spacing': ['error', 'always'],
+      'padding-line-between-statements': ['off'],
+      '@/padding-line-between-statements': ['error',
+        { blankLine: 'always', prev: '*', next: 'return' },
+        { blankLine: 'always', prev: ['const', 'let', 'var'], next: '*' },
+        { blankLine: 'any', prev: ['const', 'let', 'var'], next: ['const', 'let', 'var'] },
+        { blankLine: 'always', prev: 'directive', next: '*' },
+        { blankLine: 'any', prev: 'directive', next: 'directive' }
+      ],
+      'quotes': ['off'],
+      '@/quotes': ['error', 'single', {
+        avoidEscape: false,
+        allowTemplateLiterals: true
+      }],
+      'no-return-await': ['off'],
+      '@typescript-eslint/return-await': ['error', 'always'],
+      'semi': ['off'],
+      '@/semi': ['error', 'always'],
+      'space-before-blocks': ['off'],
+      '@/space-before-blocks': ['error'],
+      'space-before-function-paren': ['off'],
+      '@/space-before-function-paren': ['error', 'always'],
+      'space-infix-ops': ['off'],
+      '@/space-infix-ops': ['error'],
+
+      // eslint-plugin-unicorn
+      'unicorn/catch-error-name': ['error', {
+        name: 'ex'
+      }],
+      'unicorn/filename-case': ['warn', {
+        cases: {
+          camelCase: true,
+          pascalCase: true
+        }
+      }],
+      'unicorn/no-null': ['off'],
+      'unicorn/no-useless-undefined': ['off'],
+      'unicorn/prevent-abbreviations': ['warn', {
+        replacements: {
+          args: false,
+          props: false
+        }
+      }],
+      'unicorn/prefer-ternary': ['off'],
+      'unicorn/prefer-spread': ['off'],
     },
   },
 )

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "eslint-plugin-unicorn": "^55.0.0",
         "eslint-plugin-vitest": "^0.5.4",
         "globals": "^15.9.0",
+        "msw": "^2.3.5",
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.0.1",
         "vite": "^5.4.1"
@@ -352,6 +353,37 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bundled-es-modules/cookie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.0.tgz",
+      "integrity": "sha512-Or6YHg/kamKHpxULAdSqhGqnWFneIXu1NKvvfBBzKGwpVsYuFIQ5aBPHDnnoR3ghW1nvSkALd+EF9iMtY7Vjxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cookie": "^0.5.0"
+      }
+    },
+    "node_modules/@bundled-es-modules/statuses": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/statuses/-/statuses-1.0.1.tgz",
+      "integrity": "sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "statuses": "^2.0.1"
+      }
+    },
+    "node_modules/@bundled-es-modules/tough-cookie": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/tough-cookie/-/tough-cookie-0.1.6.tgz",
+      "integrity": "sha512-dvMHbL464C0zI+Yqxbz6kZ5TOEp7GLW+pry/RWndAR8MJQAXZ2rPmIs8tziTZjeIyhSNZgZbCePtfSbdWqStJw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@types/tough-cookie": "^4.0.5",
+        "tough-cookie": "^4.1.4"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -884,6 +916,68 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@inquirer/confirm": {
+      "version": "3.1.22",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-3.1.22.tgz",
+      "integrity": "sha512-gsAKIOWBm2Q87CDfs9fEo7wJT3fwWIJfnDGMn9Qy74gBnNFOACDNfhUzovubbJjWnKLGBln7/NcSmZwj5DuEXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.0.10",
+        "@inquirer/type": "^1.5.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.0.10.tgz",
+      "integrity": "sha512-TdESOKSVwf6+YWDz8GhS6nKscwzkIyakEzCLJ5Vh6O3Co2ClhCJ0A4MG909MUWfaWdpJm7DE45ii51/2Kat9tA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/figures": "^1.0.5",
+        "@inquirer/type": "^1.5.2",
+        "@types/mute-stream": "^0.0.4",
+        "@types/node": "^22.1.0",
+        "@types/wrap-ansi": "^3.0.0",
+        "ansi-escapes": "^4.3.2",
+        "cli-spinners": "^2.9.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^1.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.5.tgz",
+      "integrity": "sha512-79hP/VWdZ2UVc9bFGJnoQ/lQMpL74mGgzSYX1xUqCVk7/v73vJCMw1VuyWN1jGkZ9B3z7THAbySqGbCNefcjfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.5.2.tgz",
+      "integrity": "sha512-w9qFkumYDCNyDZmNQjf/n6qQuvQ4dMC3BJesY4oF+yr0CxR5vxujflAVeIcS6U336uzi9GM0kAfZlLrZ9UTkpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mute-stream": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
@@ -937,6 +1031,24 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.29.1.tgz",
+      "integrity": "sha512-3rDakgJZ77+RiQUuSK69t1F0m8BQKA8Vh5DCS5V0DWvNY67zob2JhhQrhCO0AKLGINTRSFd1tBaHcJTkhefoSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.2.1",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -974,6 +1086,31 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.20.0",
@@ -1244,12 +1381,39 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/mute-stream": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
+      "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.4.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.4.0.tgz",
+      "integrity": "sha512-49AbMDwYUz7EXxKU/r7mXOsxwFr4BYbvB7tWYxVuLdb2ibd30ijjXINSMAHiEEZk5PCRBmW1gUeisn2VMKt3cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
@@ -1285,6 +1449,27 @@
       "dependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.5.tgz",
+      "integrity": "sha512-jmIUGWrAiwu3dZpxntxieC+1n/5c3mjrImkmOSQ2NC5uP6cYO4aAZDdSmRcI5C1oiTmqlZGHC+/NmJrKogbP5A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/wrap-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
+      "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.1.0",
@@ -1586,6 +1771,35 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-escapes/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ansi-regex": {
@@ -1953,6 +2167,98 @@
         "node": ">=4"
       }
     },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/cliui/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -1983,6 +2289,16 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/core-js-compat": {
       "version": "3.38.0",
@@ -2167,6 +2483,13 @@
       "integrity": "sha512-HfkT8ndXR0SEkU8gBQQM3rz035bpE/hxkZ1YIt4KJPEFES68HfIU6LzKukH0H794Lm83WJtkSAMfEToxCs15VA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -3140,6 +3463,16 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
@@ -3262,6 +3595,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/graphql": {
+      "version": "16.9.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.9.0.tgz",
+      "integrity": "sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
@@ -3349,6 +3692,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
+      "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
@@ -3589,6 +3939,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-generator-function": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
@@ -3643,6 +4003,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -4064,6 +4431,149 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/msw": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.3.5.tgz",
+      "integrity": "sha512-+GUI4gX5YC5Bv33epBrD+BGdmDvBg2XGruiWnI3GbIbRmMMBeZ5gs3mJ51OWSGHgJKztZ8AtZeYMMNMVrje2/Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bundled-es-modules/cookie": "^2.0.0",
+        "@bundled-es-modules/statuses": "^1.0.1",
+        "@bundled-es-modules/tough-cookie": "^0.1.6",
+        "@inquirer/confirm": "^3.0.0",
+        "@mswjs/interceptors": "^0.29.0",
+        "@open-draft/until": "^2.1.0",
+        "@types/cookie": "^0.6.0",
+        "@types/statuses": "^2.0.4",
+        "chalk": "^4.1.2",
+        "graphql": "^16.8.1",
+        "headers-polyfill": "^4.0.2",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.2",
+        "path-to-regexp": "^6.2.0",
+        "strict-event-emitter": "^0.5.1",
+        "type-fest": "^4.9.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.7.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/msw/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/msw/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/msw/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/msw/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/msw/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/msw/node_modules/type-fest": {
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.25.0.tgz",
+      "integrity": "sha512-bRkIGlXsnGBRBQRAY56UXBm//9qH4bmJfFvq83gSz41N282df+fjy8ofcEgc1sM8geNt5cl6mC2g9Fht1cs8Aw==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
@@ -4260,6 +4770,13 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -4358,6 +4875,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
+      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4462,6 +4986,13 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/psl": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4471,6 +5002,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -4708,6 +5246,23 @@
         "jsesc": "bin/jsesc"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "2.0.0-next.5",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
@@ -4939,6 +5494,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -4994,6 +5562,38 @@
       "integrity": "sha512-xxRs31BqRYHwiMzudOrpSiHtZ8i/GeionCBDSilhYRj+9gIcI8wCZTlXZKu9vZIVqViP3dcp9qE5G6AlIaD+TQ==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.11",
@@ -5180,6 +5780,22 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
@@ -5347,6 +5963,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici-types": {
+      "version": "6.19.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.6.tgz",
+      "integrity": "sha512-e/vggGopEfTKSvj4ihnOLTsqhrKRN3LeO6qSN/GxohhuRv8qH9bNQ4B8W7e/vFL+0XTnmHPB4/kegunZGA4Org==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
@@ -5386,6 +6019,17 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/validate-npm-package-license": {
@@ -5568,12 +6212,102 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
@@ -5583,6 +6317,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
+      "integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -25,8 +25,14 @@
     "eslint-plugin-unicorn": "^55.0.0",
     "eslint-plugin-vitest": "^0.5.4",
     "globals": "^15.9.0",
+    "msw": "^2.3.5",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
     "vite": "^5.4.1"
+  },
+  "msw": {
+    "workerDirectory": [
+      "public"
+    ]
   }
 }

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -1,0 +1,284 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ * - Please do NOT serve this file on production.
+ */
+
+const PACKAGE_VERSION = '2.3.5'
+const INTEGRITY_CHECKSUM = '26357c79639bfa20d64c0efca2a87423'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+self.addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+self.addEventListener('message', async function (event) {
+  const clientId = event.source.id
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: true,
+      })
+      break
+    }
+
+    case 'MOCK_DEACTIVATE': {
+      activeClientIds.delete(clientId)
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+self.addEventListener('fetch', function (event) {
+  const { request } = event
+
+  // Bypass navigation requests.
+  if (request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been deleted (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  // Generate unique request ID.
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId))
+})
+
+async function handleRequest(event, requestId) {
+  const client = await resolveMainClient(event)
+  const response = await getResponse(event, client, requestId)
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    ;(async function () {
+      const responseClone = response.clone()
+
+      sendToClient(
+        client,
+        {
+          type: 'RESPONSE',
+          payload: {
+            requestId,
+            isMockedResponse: IS_MOCKED_RESPONSE in response,
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            body: responseClone.body,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+          },
+        },
+        [responseClone.body],
+      )
+    })()
+  }
+
+  return response
+}
+
+// Resolve the main client for the given event.
+// Client that issues a request doesn't necessarily equal the client
+// that registered the worker. It's with the latter the worker should
+// communicate with during the response resolving phase.
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+async function getResponse(event, client, requestId) {
+  const { request } = event
+
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = request.clone()
+
+  function passthrough() {
+    const headers = Object.fromEntries(requestClone.headers.entries())
+
+    // Remove internal MSW request header so the passthrough request
+    // complies with any potential CORS preflight checks on the server.
+    // Some servers forbid unknown request headers.
+    delete headers['x-msw-intention']
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const requestBuffer = await request.arrayBuffer()
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        url: request.url,
+        mode: request.mode,
+        method: request.method,
+        headers: Object.fromEntries(request.headers.entries()),
+        cache: request.cache,
+        credentials: request.credentials,
+        destination: request.destination,
+        integrity: request.integrity,
+        redirect: request.redirect,
+        referrer: request.referrer,
+        referrerPolicy: request.referrerPolicy,
+        body: requestBuffer,
+        keepalive: request.keepalive,
+      },
+    },
+    [requestBuffer],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(
+      message,
+      [channel.port2].concat(transferrables.filter(Boolean)),
+    )
+  })
+}
+
+async function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,20 @@
 import App from './App.tsx';
 import { createRoot } from 'react-dom/client';
+import { enableMocking } from './mocks/enableMocking.ts';
 import { StrictMode } from 'react';
 
+// The usage of a top level await here is essential for the mocking to work as it needs to happen before
+// the initialization of the react application.
+try {
+	await enableMocking();
+} catch (ex) {
+	console.error(ex);
+} finally {
 // We disable the no-non-null-assertion rule in this case as we are absolutely sure that we have a div with #root as id.
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-createRoot(document.getElementById('root')!).render(
-	<StrictMode>
-		<App />
-	</StrictMode>,
-);
+	createRoot(document.getElementById('root')!).render(
+		<StrictMode>
+			<App />
+		</StrictMode>,
+	);
+}

--- a/src/mocks/README.md
+++ b/src/mocks/README.md
@@ -1,0 +1,8 @@
+# mocks
+
+This directory contains the mocking functionality of the application. It contains the mocks for the api endpoints mainly.
+
+## mocked endpoints
+
+- `/test` - (get) This endpoint is used as a test endpoint. The assets are stored in memory for the purpose of this demo.
+- `/products-listing` - (get) This endpoint is used to get the list of the products. It returns array of [Product](/src/types/Product.ts). The products are stored in memory for the purpose of this demo.

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -1,0 +1,4 @@
+import { handlers } from './handlers';
+import { setupWorker } from 'msw/browser';
+
+export const worker = setupWorker(...handlers);

--- a/src/mocks/enableMocking.ts
+++ b/src/mocks/enableMocking.ts
@@ -1,0 +1,10 @@
+const enableMocking = async (): Promise<ServiceWorkerRegistration | undefined> => {
+	if (!import.meta.env.DEV) {
+		return;
+	}
+	const { worker } = await import('./browser');
+
+	return await worker.start();
+};
+
+export { enableMocking };

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,0 +1,69 @@
+import type { Product } from '../types/Product';
+import type { DefaultBodyType, HttpHandler, PathParams } from 'msw';
+import { delay, http, HttpResponse } from 'msw';
+
+// the initial data to be fetched by the client supposedly stored in a database
+const data = {
+	products: [
+		{
+			'id': 1,
+			'name': 'Product 1',
+			'category': 'Category A',
+			'price': 29.99,
+		},
+		{
+			'id': 2,
+			'name': 'Product 2',
+			'category': 'Category A',
+			'price': 49.99,
+		},
+		{
+			'id': 3,
+			'name': 'Product 3',
+			'category': 'Category B',
+			'price': 29.99,
+		},
+		{
+			'id': 4,
+			'name': 'Product 4',
+			'category': 'Category B',
+			'price': 49.99,
+		},
+		{
+			'id': 5,
+			'name': 'Product 5',
+			'category': 'Category A',
+			'price': 59.99,
+		},
+		{
+			'id': 6,
+			'name': 'Product 6',
+			'category': 'Category B',
+			'price': 69.99,
+		},
+		{
+			'id': 7,
+			'name': 'Product 7',
+			'category': 'Category A',
+			'price': 89.99,
+		},
+	] as Product[],
+};
+
+const handlers: HttpHandler[] =
+	[
+		http.get<PathParams, DefaultBodyType, { message: string }>('/test', async () => {
+			// simulate loading
+			await delay(10_000);
+
+			return HttpResponse.json({ message: 'Hello Mocked World!' });
+		}),
+
+		http.get<PathParams, DefaultBodyType, Product[]>('/product-listing', async () => {
+			await delay(3000);
+
+			return HttpResponse.json([ ...data.products ]);
+		}),
+	];
+
+export { handlers };

--- a/src/types/Product.ts
+++ b/src/types/Product.ts
@@ -1,0 +1,10 @@
+// TODO: add ProductSchema for runtime validation with zod
+
+interface Product {
+    category: string;
+    id: number;
+    name: string;
+    price: number
+}
+
+export type { Product };


### PR DESCRIPTION
In this PR, the mocking setup is completely integrated and ready to be used by the application. The [msw](https://mswjs.io/) library was used for the mocking as it allows for a real simulation of a web server on the client. It should only be used in development mode however. 