### PR TITLE
chore: remove unnacessary await

### DIFF
--- a/src/mocks/enableMocking.ts
+++ b/src/mocks/enableMocking.ts
@@ -9,7 +9,8 @@ const enableMocking = async (): Promise<ServiceWorkerRegistration | undefined> =
 	}
 	const { worker } = await import('./browser');
 
-	return await worker.start();
+	// eslint-disable-next-line @typescript-eslint/return-await
+	return worker.start();
 };
 
 export { enableMocking };


### PR DESCRIPTION
This PR fixes a bug where the application might not load initially due to the `enableMocking` function returning an awaited Promise instead of a Promise.